### PR TITLE
Fix Ascon-80pq tag by padding key's final 4 bytes (for big-endian conv)

### DIFF
--- a/ascon.py
+++ b/ascon.py
@@ -266,7 +266,8 @@ def ascon_finalize(S, rate, a, key):
     assert(len(key) in [16,20])
     S[rate//8+0] ^= bytes_to_int(key[0:8])
     S[rate//8+1] ^= bytes_to_int(key[8:16])
-    S[rate//8+2] ^= bytes_to_int(key[16:])
+    p_key = key + zero_bytes(4)
+    S[rate//8+2] ^= bytes_to_int(p_key[16:])
 
     ascon_permutation(S, a)
 


### PR DESCRIPTION
Tested w/ vectors from C reference impl `genkat_crypto_aead_ascon80pqv12_ref.exe` like this
```
if __name__ == "__main__":
    variant = "Ascon-80pq"
    key   = bytes.fromhex("000102030405060708090A0B0C0D0E0F10111213")
    nonce = bytes.fromhex("000102030405060708090A0B0C0D0E0F")
    associateddata = bytes.fromhex("000102030405")
    plaintext      = bytes.fromhex("000102030405")
    ciphertext        = ascon_encrypt(key, nonce, associateddata, plaintext,  variant)
    receivedplaintext = ascon_decrypt(key, nonce, associateddata, ciphertext, variant)
    demo_print([("key", key),
                ("nonce", nonce),
                ("plaintext", plaintext),
                ("ass.data", associateddata),
                ("ciphertext", ciphertext[:-16]),
                ("tag", ciphertext[-16:]),
                ("received", receivedplaintext),
               ])
```