### PR TITLE
Added typing annotations

### DIFF
--- a/genkat.py
+++ b/genkat.py
@@ -7,13 +7,22 @@ KAT implementation for NIST (based on TestVectorGen.zip)
 import ascon
 import sys
 from writer import MultipleWriter
+from typing import Literal, TypeAlias
 
+AsconVariants: TypeAlias = Literal[
+    "Ascon-AEAD128",
+    "Ascon-Hash256",
+    "Ascon-XOF128",
+    "Ascon-CXOF128",
+    "Ascon-Mac",
+    "Ascon-Prf",
+    "Ascon-PrfShort"
+]
 
-def kat_bytes(length):
+def kat_bytes(length: int) -> bytes:
     return bytes(bytearray([i % 256 for i in range(length)]))
 
-
-def kat_aead(variant):
+def kat_aead(variant: AsconVariants) -> None:
     MAX_MESSAGE_LENGTH = 32
     MAX_ASSOCIATED_DATA_LENGTH = 32
 
@@ -48,7 +57,7 @@ def kat_aead(variant):
                 w.close()
 
 
-def kat_hash(variant="Ascon-Hash256"):
+def kat_hash(variant: AsconVariants = "Ascon-Hash256") -> None:
     MAX_MESSAGE_LENGTH = 1024
     hlen = 32  # =CRYPTO_BYTES
     hashtypes = {"Ascon-Hash256": "HASH",
@@ -71,7 +80,7 @@ def kat_hash(variant="Ascon-Hash256"):
             w.close()
 
 
-def kat_cxof(variant="Ascon-CXOF128"):
+def kat_cxof(variant: AsconVariants = "Ascon-CXOF128") -> None:
     # proposed KAT format - not official reference
     MAX_MESSAGE_LENGTH = 32
     MAX_CUSTOMIZATION_LENGTH = 32
@@ -97,7 +106,7 @@ def kat_cxof(variant="Ascon-CXOF128"):
                 w.close()
 
 
-def kat_auth(variant="Ascon-Mac"):
+def kat_auth(variant: AsconVariants = "Ascon-Mac") -> None:
     MAX_MESSAGE_LENGTH = 1024
     if variant == "Ascon-PrfShort": MAX_MESSAGE_LENGTH = 16
     klen = 16
@@ -120,7 +129,7 @@ def kat_auth(variant="Ascon-Mac"):
             w.close()
 
 
-def kat(variant):
+def kat(variant: AsconVariants) -> None:
     aead_variants = ["Ascon-AEAD128"]
     hash_variants = ["Ascon-Hash256", "Ascon-XOF128", "Ascon-CXOF128"]
     cxof_variants = ["Ascon-CXOF128"] # will produce two KATs (hash+cxof)

--- a/writer.py
+++ b/writer.py
@@ -4,45 +4,80 @@
 Writers for output test vectors in Text and JSON formats.
 """
 
+from typing import Type, Any, Optional, Self, overload
+from types import TracebackType
+from io import TextIOWrapper
+from abc import ABC, abstractmethod
 
-class TextWriter:
+class GenericWriter(ABC):
+    """
+    GenericWriter used as a base class for all writers for better typing.
+    """
+    def __init__(self, filename: str) -> None:
+        self.fp : TextIOWrapper
+
+    @abstractmethod
+    def __enter__(self) -> Self:
+        pass
+
+    @abstractmethod
+    def __exit__(self, stype: Optional[Type[BaseException]], value: Optional[BaseException], traceback: Optional[TracebackType]) -> None:
+        pass
+
+    @abstractmethod
+    def append(self, label: Any, value: Any, length: Optional[int] = None) -> None:
+        pass
+
+    @abstractmethod
+    def open(self) -> None:
+        pass
+
+    @abstractmethod
+    def close(self) -> None:
+        pass
+
+class TextWriter(GenericWriter):
     """
     TextWriter produces an array of key-value objects.
     """
 
-    def __init__(self, filename):
+    def __init__(self, filename: str) -> None:
+        super().__init__(filename)
         self.fp = open(filename + ".txt", "w")
         self.is_open = False
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         return self
 
-    def __exit__(self, stype, value, traceback):
+    def __exit__(self, stype: Optional[Type[BaseException]], value: Optional[BaseException], traceback: Optional[TracebackType]) -> None:
         pass
 
-    def append(self, label, value, length=None):
+    def append(self, label: Any, value: Any, length: Optional[int] = None) -> None:
         assert self.is_open, "cannot append if not open yet"
         if length is not None:
+            assert isinstance(value, bytes), "length can only be specified for value of type bytes"
             assert len(value) >= length
             value = value[:length].hex().upper()
+            
         self.fp.write("{} = {}\n".format(label, value))
 
-    def open(self):
+    def open(self) -> None:
         assert not self.is_open, "cannot open twice"
         self.is_open = True
 
-    def close(self):
+    def close(self) -> None:
         assert self.is_open, "cannot close if not open first"
         self.fp.write("\n")
         self.is_open = False
 
 
-class JSONWriter:
+class JSONWriter(GenericWriter):
     """
     JSONWriter produces an array of JSON objects.
     """
 
-    def __init__(self, filename):
+    def __init__(self, filename: str) -> None:
+        super().__init__(filename)
         self.level = 1
         self.fp = open(filename + ".json", "w")
         self.has_item = False
@@ -52,61 +87,63 @@ class JSONWriter:
             (self.level > 0 or self.has_item) + self.tab * self.level
         self.fp.write("[")
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         return self
 
-    def __exit__(self, stype, value, traceback):
+    def __exit__(self, stype: Optional[Type[BaseException]], value: Optional[BaseException], traceback: Optional[TracebackType]) -> None:
         self.level -= 1
         self.fp.write("{}]\n".format(self.ws()))
 
-    def append(self, label, value, length=None):
+    def append(self, label: Any, value: Any, length: Optional[int] = None):
         if length is not None:
+            assert isinstance(value, bytes), "length can only be specified for value of type bytes"
             assert len(value) >= length
             value = '"{}"'.format(value[:length].hex().upper())
         self.fp.write('{}{}"{}": {}'.format(
             self.comma(), self.ws(), label, value))
         self.has_item = True
 
-    def open(self):
+    def open(self) -> None:
         assert (self.level > 0 or not self.has_item)
         self.fp.write("{}{}{{".format(self.comma(), self.ws()))
         self.level += 1
         self.has_item = False
 
-    def close(self):
+    def close(self) -> None:
         assert (self.level > 0 or not self.has_item)
         self.level -= 1
         self.fp.write("{}}}".format(self.ws()))
         self.has_item = True
 
 
-class MultipleWriter:
+class MultipleWriter(GenericWriter):
     """
     Merge multiple writers to ease invocation.
     """
 
-    def __init__(self, filename):
-        self.writers = [JSONWriter(filename), TextWriter(filename)]
+    def __init__(self, filename: str) -> None:
+        super().__init__(filename)
+        self.writers: list[GenericWriter] = [JSONWriter(filename), TextWriter(filename)]
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         for w in self.writers:
             w.__enter__()
         return self
 
-    def __exit__(self, stype, value, traceback):
+    def __exit__(self, stype: Optional[Type[BaseException]], value: Optional[BaseException], traceback: Optional[TracebackType]) -> None:
         for w in self.writers:
             w.__exit__(stype, value, traceback)
             w.fp.close()
 
-    def open(self):
+    def open(self) -> None:
         for w in self.writers:
             w.open()
 
-    def append(self, label, value, length=None):
+    def append(self, label: Any, value: Any, length: Optional[int] = None) -> None:
         for w in self.writers:
             w.append(label, value, length)
 
-    def close(self):
+    def close(self) -> None:
         for w in self.writers:
             w.close()
 


### PR DESCRIPTION
Added typing annotations with syntax compatible with python versions prior to 3.10. Added a few asserts and tweaks to better ensure correct provided types. Added GenericWriter abstract class for typing purpose only.