### PR TITLE
Improve Type Annotations and Other Improvements

### DIFF
--- a/ascon.py
+++ b/ascon.py
@@ -419,23 +419,23 @@ def ff_bytes(n: int) -> bytes:
 
 def to_bytes(l: BytesLike|Iterable[int]) -> bytes:
     # where l is a list or bytearray or bytes
-    return bytes(bytearray(l))
+    return bytes(l)
 
 def bytes_to_int(bytes: BytesLike) -> int:
+    return int.from_bytes(bytes, 'little')
     return sum([bi << (i*8) for i, bi in enumerate(to_bytes(bytes))])
 
 def bytes_to_state(bytes: bytes) -> list[int]:
     return [bytes_to_int(bytes[8*w:8*(w+1)]) for w in range(5)]
 
 def int_to_bytes(integer: int, nbytes: int) -> bytes:
-    return to_bytes([(integer >> (i * 8)) % 256 for i in range(nbytes)])
+    return integer.to_bytes(nbytes, 'little')
 
 def rotr(val: int, r: int) -> int:
     return (val >> r) | ((val & (1<<r)-1) << (64-r))
 
 def bytes_to_hex(b: bytes) -> str:
     return b.hex()
-    #return "".join(x.encode('hex') for x in b)
 
 def printstate(S: list[int], description: str = "") -> None:
     print(" " + description)

--- a/ascon.py
+++ b/ascon.py
@@ -66,7 +66,7 @@ def ascon_hash(message: BytesLike, variant: AsconHashVariant|AsconCxofVariant = 
     if debug: printstate(S, "initialization:")
 
     # Customization
-    if customize: 
+    if customize:
         z_padding = to_bytes([0x01]) + zero_bytes(rate - (len(customization) % rate) - 1)
         z_length = int_to_bytes(len(customization)*8, 8)
         z_padded = z_length + customization + z_padding
@@ -174,7 +174,7 @@ def ascon_mac(key: BytesLike, message: BytesLike, variant: AsconMacVariant = "As
 
 # === Ascon AEAD encryption and decryption ===
 
-def ascon_encrypt(key: BytesLike, nonce: BytesLike, associateddata: BytesLike, plaintext: BytesLike, variant: AsconAeadVariant = "Ascon-AEAD128") -> bytes: 
+def ascon_encrypt(key: BytesLike, nonce: BytesLike, associateddata: BytesLike, plaintext: BytesLike, variant: AsconAeadVariant = "Ascon-AEAD128") -> bytes:
     """
     Ascon encryption.
     key: a bytes object of size 16 (for Ascon-AEAD128; 128-bit security)
@@ -316,7 +316,7 @@ def ascon_process_plaintext(S: list[int], b: int, rate: int, plaintext: BytesLik
 
 def ascon_process_ciphertext(S: list[int], b: int, rate: int, ciphertext: BytesLike):
     """
-    Ascon ciphertext processing phase (during decryption) - internal helper function. 
+    Ascon ciphertext processing phase (during decryption) - internal helper function.
     S: Ascon state, a list of 5 64-bit integers
     b: number of intermediate rounds for permutation
     rate: block size in bytes (16 for Ascon-AEAD128)
@@ -461,7 +461,7 @@ def demo_aead(variant: AsconAeadVariant = "Ascon-AEAD128") -> None:
     # choose a cryptographically strong random key and a nonce that never repeats for the same key:
     key   = get_random_bytes(16)  # zero_bytes(16)
     nonce = get_random_bytes(16)  # zero_bytes(16)
-    
+
     associateddata = b"ASCON"
     plaintext      = b"ascon"
 
@@ -469,14 +469,14 @@ def demo_aead(variant: AsconAeadVariant = "Ascon-AEAD128") -> None:
     receivedplaintext = ascon_decrypt(key, nonce, associateddata, ciphertext, variant)
 
     if receivedplaintext is None: print("verification failed!")
-        
-    demo_print([("key", key), 
-                ("nonce", nonce), 
-                ("plaintext", plaintext), 
-                ("ass.data", associateddata), 
-                ("ciphertext", ciphertext[:-16]), 
-                ("tag", ciphertext[-16:]), 
-                ("received", receivedplaintext), 
+
+    demo_print([("key", key),
+                ("nonce", nonce),
+                ("plaintext", plaintext),
+                ("ass.data", associateddata),
+                ("ciphertext", ciphertext[:-16]),
+                ("tag", ciphertext[-16:]),
+                ("received", receivedplaintext),
                ])
 
 def demo_hash(variant: AsconHashVariant|AsconCxofVariant = "Ascon-Hash256", hashlength: int = 32) -> None:

--- a/genkat.py
+++ b/genkat.py
@@ -56,7 +56,7 @@ def kat_hash(variant: ascon.AsconHashVariant|ascon.AsconCxofVariant = "Ascon-Has
                  "Ascon-XOF128": "HASH",  # or: XOF
                  "Ascon-CXOF128": "HASH"} # or: CXOF
     assert variant in hashtypes.keys()
-    
+
     filename = "LWC_{hashtype}_KAT_{hlenbits}".format(hashtype=hashtypes[variant], hlenbits=hlen*8)
 
     msg = kat_bytes(MAX_MESSAGE_LENGTH)
@@ -79,7 +79,7 @@ def kat_cxof(variant: Literal["Ascon-CXOF128"] = "Ascon-CXOF128") -> None:
     hlen = 32  # =CRYPTO_BYTES
     cxoftypes = {"Ascon-CXOF128": "CXOF"}
     assert variant in cxoftypes.keys()
-    
+
     filename = "LWC_{cxoftype}_KAT_{hlenbits}".format(cxoftype=cxoftypes[variant], hlenbits=hlen*8)
 
     msg    = kat_bytes(MAX_MESSAGE_LENGTH)

--- a/genkat.py
+++ b/genkat.py
@@ -7,13 +7,22 @@ KAT implementation for NIST (based on TestVectorGen.zip)
 import ascon
 import sys
 from writer import MultipleWriter
+from typing import Literal, TypeAlias
 
+AsconVariants: TypeAlias = Literal[
+    "Ascon-AEAD128",
+    "Ascon-Hash256",
+    "Ascon-XOF128",
+    "Ascon-CXOF128",
+    "Ascon-Mac",
+    "Ascon-Prf",
+    "Ascon-PrfShort"
+]
 
-def kat_bytes(length):
+def kat_bytes(length: int) -> bytes:
     return bytes(bytearray([i % 256 for i in range(length)]))
 
-
-def kat_aead(variant):
+def kat_aead(variant: AsconVariants) -> None:
     MAX_MESSAGE_LENGTH = 32
     MAX_ASSOCIATED_DATA_LENGTH = 32
 
@@ -48,7 +57,7 @@ def kat_aead(variant):
                 w.close()
 
 
-def kat_hash(variant="Ascon-Hash256"):
+def kat_hash(variant: AsconVariants = "Ascon-Hash256") -> None:
     MAX_MESSAGE_LENGTH = 1024
     hlen = 32  # =CRYPTO_BYTES
     hashtypes = {"Ascon-Hash256": "HASH",
@@ -71,7 +80,7 @@ def kat_hash(variant="Ascon-Hash256"):
             w.close()
 
 
-def kat_cxof(variant="Ascon-CXOF128"):
+def kat_cxof(variant: AsconVariants = "Ascon-CXOF128") -> None:
     # proposed KAT format - not official reference
     MAX_MESSAGE_LENGTH = 32
     MAX_CUSTOMIZATION_LENGTH = 32
@@ -97,7 +106,7 @@ def kat_cxof(variant="Ascon-CXOF128"):
                 w.close()
 
 
-def kat_auth(variant="Ascon-Mac"):
+def kat_auth(variant: AsconVariants = "Ascon-Mac") -> None:
     MAX_MESSAGE_LENGTH = 1024
     if variant == "Ascon-PrfShort": MAX_MESSAGE_LENGTH = 16
     klen = 16
@@ -120,7 +129,7 @@ def kat_auth(variant="Ascon-Mac"):
             w.close()
 
 
-def kat(variant):
+def kat(variant: AsconVariants) -> None:
     aead_variants = ["Ascon-AEAD128"]
     hash_variants = ["Ascon-Hash256", "Ascon-XOF128", "Ascon-CXOF128"]
     cxof_variants = ["Ascon-CXOF128"] # will produce two KATs (hash+cxof)

--- a/writer.py
+++ b/writer.py
@@ -4,45 +4,80 @@
 Writers for output test vectors in Text and JSON formats.
 """
 
+from typing import Type, Any, Optional, Self, overload
+from types import TracebackType
+from io import TextIOWrapper
+from abc import ABC, abstractmethod
 
-class TextWriter:
+class GenericWriter(ABC):
+    """
+    GenericWriter used as a base class for all writers for better typing.
+    """
+    def __init__(self, filename: str) -> None:
+        self.fp : TextIOWrapper
+
+    @abstractmethod
+    def __enter__(self) -> Self:
+        pass
+
+    @abstractmethod
+    def __exit__(self, stype: Optional[Type[BaseException]], value: Optional[BaseException], traceback: Optional[TracebackType]) -> None:
+        pass
+
+    @abstractmethod
+    def append(self, label: Any, value: Any, length: Optional[int] = None) -> None:
+        pass
+
+    @abstractmethod
+    def open(self) -> None:
+        pass
+
+    @abstractmethod
+    def close(self) -> None:
+        pass
+
+class TextWriter(GenericWriter):
     """
     TextWriter produces an array of key-value objects.
     """
 
-    def __init__(self, filename):
+    def __init__(self, filename: str) -> None:
+        super().__init__(filename)
         self.fp = open(filename + ".txt", "w")
         self.is_open = False
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         return self
 
-    def __exit__(self, stype, value, traceback):
+    def __exit__(self, stype: Optional[Type[BaseException]], value: Optional[BaseException], traceback: Optional[TracebackType]) -> None:
         pass
 
-    def append(self, label, value, length=None):
+    def append(self, label: Any, value: Any, length: Optional[int] = None) -> None:
         assert self.is_open, "cannot append if not open yet"
         if length is not None:
+            assert isinstance(value, bytes), "length can only be specified for value of type bytes"
             assert len(value) >= length
             value = value[:length].hex().upper()
+            
         self.fp.write("{} = {}\n".format(label, value))
 
-    def open(self):
+    def open(self) -> None:
         assert not self.is_open, "cannot open twice"
         self.is_open = True
 
-    def close(self):
+    def close(self) -> None:
         assert self.is_open, "cannot close if not open first"
         self.fp.write("\n")
         self.is_open = False
 
 
-class JSONWriter:
+class JSONWriter(GenericWriter):
     """
     JSONWriter produces an array of JSON objects.
     """
 
-    def __init__(self, filename):
+    def __init__(self, filename: str) -> None:
+        super().__init__(filename)
         self.level = 1
         self.fp = open(filename + ".json", "w")
         self.has_item = False
@@ -52,61 +87,63 @@ class JSONWriter:
             (self.level > 0 or self.has_item) + self.tab * self.level
         self.fp.write("[")
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         return self
 
-    def __exit__(self, stype, value, traceback):
+    def __exit__(self, stype: Optional[Type[BaseException]], value: Optional[BaseException], traceback: Optional[TracebackType]) -> None:
         self.level -= 1
         self.fp.write("{}]\n".format(self.ws()))
 
-    def append(self, label, value, length=None):
+    def append(self, label: Any, value: Any, length: Optional[int] = None):
         if length is not None:
+            assert isinstance(value, bytes), "length can only be specified for value of type bytes"
             assert len(value) >= length
             value = '"{}"'.format(value[:length].hex().upper())
         self.fp.write('{}{}"{}": {}'.format(
             self.comma(), self.ws(), label, value))
         self.has_item = True
 
-    def open(self):
+    def open(self) -> None:
         assert (self.level > 0 or not self.has_item)
         self.fp.write("{}{}{{".format(self.comma(), self.ws()))
         self.level += 1
         self.has_item = False
 
-    def close(self):
+    def close(self) -> None:
         assert (self.level > 0 or not self.has_item)
         self.level -= 1
         self.fp.write("{}}}".format(self.ws()))
         self.has_item = True
 
 
-class MultipleWriter:
+class MultipleWriter(GenericWriter):
     """
     Merge multiple writers to ease invocation.
     """
 
-    def __init__(self, filename):
-        self.writers = [JSONWriter(filename), TextWriter(filename)]
+    def __init__(self, filename: str) -> None:
+        super().__init__(filename)
+        self.writers: list[GenericWriter] = [JSONWriter(filename), TextWriter(filename)]
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         for w in self.writers:
             w.__enter__()
         return self
 
-    def __exit__(self, stype, value, traceback):
+    def __exit__(self, stype: Optional[Type[BaseException]], value: Optional[BaseException], traceback: Optional[TracebackType]) -> None:
         for w in self.writers:
             w.__exit__(stype, value, traceback)
             w.fp.close()
 
-    def open(self):
+    def open(self) -> None:
         for w in self.writers:
             w.open()
 
-    def append(self, label, value, length=None):
+    def append(self, label: Any, value: Any, length: Optional[int] = None) -> None:
         for w in self.writers:
             w.append(label, value, length)
 
-    def close(self):
+    def close(self) -> None:
         for w in self.writers:
             w.close()
 

--- a/writer.py
+++ b/writer.py
@@ -54,7 +54,7 @@ class TextWriter(GenericWriter):
             assert isinstance(value, bytes), "length can only be specified for value of type bytes"
             assert len(value) >= length
             value = value[:length].hex().upper()
-            
+
         self.fp.write("{} = {}\n".format(label, value))
 
     def open(self) -> None:


### PR DESCRIPTION
This pull requests builds upon #5.

- I improved the proposed type annotations as follows:
    - For parameters, I replaced `bytes` with `BytesLike = bytes|bytearray|memoryview` to allow more flexibility for parameters consistent with other cryptographic libraries like `hashlib` and `pyca/cryptography`
    - I replaced the deprecated types like `typing.List[...]` with built-ins like `list[...]`, as the built-ins now also support generic parameters. For compatibility with older Python versions, I added `from __future__ import annotations`
    - I split up the `AsconVariant` type into the subtypes `AsconAeadVariant`, `AsconHashVariant`, `AsconCxofVariant`, and `AsconMacVariant`
    - In many cases, I replaced `assert variant in ['Ascon-...', ...]` with `assert variant in ('Ascon-...', ...)` as many type checkers perform more detailed type reasoning for tuples compared to lists.
    - I strengthened the types annotations for the `GenericWriter` class by introducing overloads for bytes + optional length and integers.
- My other improvements are as follows:
    - I refactored `int_to_bytes(...)` to use `integer.to_bytes(nbytes, 'little')` which is cleaner and faster
    - I removed an unnecessary copy in `to_bytes` by converting to `bytes` directly without the in-between `bytearray`
    - I moved the `fp.close()` call from the `MultipleWriter` class to the `__exit__()` method of each individual writer
    - I cleaned whitespace issues by removing white space from empty lines